### PR TITLE
Fixed NTLMv2 Response Algorithm

### DIFF
--- a/python2/smb/ntlm.py
+++ b/python2/smb/ntlm.py
@@ -163,12 +163,11 @@ def generateChallengeResponseV2(password, user, server_challenge, server_info, d
     d.update(password.encode('UTF-16LE'))
     ntlm_hash = d.digest()   # The NT password hash
     response_key = hmac.new(ntlm_hash, (user.upper() + domain).encode('UTF-16LE')).digest()  # The NTLMv2 password hash. In [MS-NLMP], this is the result of NTOWFv2 and LMOWFv2 functions
-    temp = '\x01\x01' + '\0'*6 + client_timestamp + client_challenge + '\0'*4 + server_info
-    ntproofstr = hmac.new(response_key, server_challenge + temp).digest()
+    temp = client_timestamp + client_challenge + domain + server_info
 
-    nt_challenge_response = ntproofstr + temp
+    nt_challenge_response = hmac.new(response_key, server_challenge + temp).digest()
     lm_challenge_response = hmac.new(response_key, server_challenge + client_challenge).digest() + client_challenge
-    session_key = hmac.new(response_key, ntproofstr).digest()
+    session_key = hmac.new(response_key, nt_challenge_response).digest()
 
     return nt_challenge_response, lm_challenge_response, session_key
 


### PR DESCRIPTION
Encountered an issue when using "server signing" option set to "mandatory" with samba 3.0.28. It seemed to be related to the algorithm used in the function generateChallengeResponseV2.